### PR TITLE
Adding the virtualenv $PATH to execution context to take advantage of…

### DIFF
--- a/venv.go
+++ b/venv.go
@@ -90,7 +90,7 @@ func (c VenvCommand) Run() (string, string, error) {
 
 	path, ok := os.LookupEnv("PATH")
 	if !ok {
-		logrus.Error("unable to lookup the $PATH env variable")
+		return "", "", errors.New("Unable to lookup the $PATH env variable")
 	}
 
 	// Updating $PATH variable to include the venv path

--- a/venv.go
+++ b/venv.go
@@ -5,9 +5,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -85,6 +87,19 @@ func (c VenvCommand) Run() (string, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), venvCommandTimeout)
 
 	defer cancel() // The cancel should be deferred so resources are cleaned up
+
+	path, ok := os.LookupEnv("PATH")
+	if !ok {
+		logrus.Error("unable to lookup the $PATH env variable")
+	}
+
+	// Updating $PATH variable to include the venv path
+	venvPath := filepath.Join(c.Config.Path, "bin")
+	if !strings.Contains(path, venvPath) {
+		newVenvPath := fmt.Sprintf("%s:%s", filepath.Join(c.Config.Path, "bin"), path)
+		logrus.Debugln("PATH: ", newVenvPath)
+		os.Setenv("PATH", newVenvPath)
+	}
 
 	cmd := exec.CommandContext(
 		ctx,


### PR DESCRIPTION
… ansible libraries such as the ones used in ec2.py

```
$ go test                                                                                                                                                                                                                                                      
{"level":"info","msg":"Disabled Ansible-Puller","time":"2019-09-09T11:58:14-07:00"}
Running Suite: Ansible Puller Suite
===================================
Random Seed: 1568055494
Will run 12 of 12 specs

••••••••••••
Ran 12 of 12 Specs in 0.020 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/teslamotors/ansible_puller	0.741s
```