### PR TITLE
Adding IP support to the inventory so that you can use ip address instead of simply hostnames as a way to designate hosts in your inventories

### DIFF
--- a/ansible.go
+++ b/ansible.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -25,19 +26,19 @@ type AnsibleConfig struct {
 }
 
 // CreateAnsibleTargetsList generates and returns an array of possible targets
-// The possible targets are ip addresse from the host interfaces or the hostname itself
-func CreateAnsibleTargetsList() []string {
+// The possible targets are ip addresses from the host interfaces or the hostname itself
+func CreateAnsibleTargetsList() ([]string, error) {
 	var inventoryTargets = []string{}
 
 	// extract all ip addresses except the loopback one and add the hostname as a last fallback mechanism
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		logrus.Fatal("Unable to get the network interfaces")
+		return []string{}, errors.Wrap(err, "Unable to get the network interfaces")
 	}
 	for _, i := range ifaces {
 		addrs, err := i.Addrs()
 		if err != nil {
-			logrus.Fatal("Unable to extract the ip addresses")
+			return []string{}, errors.Wrap(err, fmt.Sprintf("Unable to extract the ip addresses from %s", i.Name))
 		}
 		for _, addr := range addrs {
 			var ip net.IP
@@ -54,11 +55,11 @@ func CreateAnsibleTargetsList() []string {
 		}
 	}
 	inventoryTargets = append(inventoryTargets, hostname)
-	return inventoryTargets
+	return inventoryTargets, nil
 }
 
 // FindInventoryForHost calls CreateAnsibleTargetsList to get a list of possible targets
-// and returns the traget and inventory where the target was found.
+// and returns the inventory and target that was found in that inventory.
 // It stops on the first target match meaning that it assumes that hosts are
 // defined by only 1 type of target like their eth0 ip address or hostname
 // If the host was not found, it returns an error.
@@ -68,37 +69,38 @@ func CreateAnsibleTargetsList() []string {
 //
 // The given hostname should be the full name that appears in the Ansible inventories.
 func (a AnsibleConfig) FindInventoryForHost() (string, string, error) {
-	targets := CreateAnsibleTargetsList()
-	for _, target := range targets {
-		for _, item := range a.InventoryList {
-			inv := filepath.Join(a.Cwd, item)
-			_, err := os.Stat(inv)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return "", "", errors.Wrapf(err, "unable to find inventory: %s", item)
-				}
-
-				return "", "", err
+	targets, err := CreateAnsibleTargetsList()
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to perform the CreateAnsibleTargetsList command")
+	}
+	for _, item := range a.InventoryList {
+		inv := filepath.Join(a.Cwd, item)
+		_, err := os.Stat(inv)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", "", errors.Wrapf(err, "unable to find inventory: %s", item)
 			}
 
-			vCmd := VenvCommand{
-				Config: a.VenvConfig,
-				Binary: "ansible-playbook",
-				Args:   []string{viper.GetString("ansible-playbook"), "-i", inv, "--list-hosts"},
-				Cwd:    a.Cwd,
-			}
+			return "", "", err
+		}
 
-			output, _, err := vCmd.Run()
-			if err != nil {
-				logrus.Debugln("Ansible inventory output:", output)
-				return "", "", errors.Wrap(err, "unable to list hosts for "+item)
-			}
+		vCmd := VenvCommand{
+			Config: a.VenvConfig,
+			Binary: "ansible-playbook",
+			Args:   []string{viper.GetString("ansible-playbook"), "-i", inv, "--list-hosts"},
+			Cwd:    a.Cwd,
+		}
 
+		output, _, err := vCmd.Run()
+		if err != nil {
+			logrus.Debugln("Ansible inventory output:", output)
+			return "", "", errors.Wrap(err, "unable to list hosts for "+item)
+		}
+		for _, target := range targets {
 			if strings.Contains(output, target) {
 				logrus.Debug("Found ", target, " in inventory ", inv)
 				return inv, target, nil
 			}
-
 			logrus.Debug("Did not find ", target, " in inventory ", inv)
 		}
 	}

--- a/ansible.go
+++ b/ansible.go
@@ -4,12 +4,14 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // AnsibleConfig is a collection of meta-information about an Ansible repository.
@@ -17,52 +19,90 @@ import (
 // The virtualenv specified by the VenvConfig needs to be initialized before running Ansible commands.
 // All dir paths are relative to the root of the source tarball.
 type AnsibleConfig struct {
-	VenvConfig         VenvConfig // Virtualenv config that Ansible will be executed in
-	Cwd                string     // Path to change to when running Ansible commands
-	InventoryList      []string   // Paths to all desired inventories
+	VenvConfig    VenvConfig // Virtualenv config that Ansible will be executed in
+	Cwd           string     // Path to change to when running Ansible commands
+	InventoryList []string   // Paths to all desired inventories
 }
 
-// FindInventoryForHost takes a hostname and returns the inventory where the host was found.
+// CreateAnsibleTargetsList generates and returns an array of possible targets
+// The possible targets are ip addresse from the host interfaces or the hostname itself
+func CreateAnsibleTargetsList() []string {
+	var inventoryTargets = []string{}
+
+	// extract all ip addresses except the loopback one and add the hostname as a last fallback mechanism
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		logrus.Fatal("Unable to get the network interfaces")
+	}
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			logrus.Fatal("Unable to extract the ip addresses")
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			inventoryTargets = append(inventoryTargets, ip.String())
+		}
+	}
+	inventoryTargets = append(inventoryTargets, hostname)
+	return inventoryTargets
+}
+
+// FindInventoryForHost calls CreateAnsibleTargetsList to get a list of possible targets
+// and returns the traget and inventory where the target was found.
+// It stops on the first target match meaning that it assumes that hosts are
+// defined by only 1 type of target like their eth0 ip address or hostname
 // If the host was not found, it returns an error.
 //
 // This will check against all of the defined inventories in ansibleCfg.InventoryList,
 // relative to the path defined in ansibleCfg.Cwd.
 //
 // The given hostname should be the full name that appears in the Ansible inventories.
-func (a AnsibleConfig) FindInventoryForHost(host string) (string, error) {
-	for _, item := range a.InventoryList {
-		inv := filepath.Join(a.Cwd, item)
-		_, err := os.Stat(inv)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return "", errors.Wrapf(err, "unable to find inventory: %s", item)
+func (a AnsibleConfig) FindInventoryForHost() (string, string, error) {
+	targets := CreateAnsibleTargetsList()
+	for _, target := range targets {
+		for _, item := range a.InventoryList {
+			inv := filepath.Join(a.Cwd, item)
+			_, err := os.Stat(inv)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return "", "", errors.Wrapf(err, "unable to find inventory: %s", item)
+				}
+
+				return "", "", err
 			}
 
-			return "", err
-		}
+			vCmd := VenvCommand{
+				Config: a.VenvConfig,
+				Binary: "ansible-playbook",
+				Args:   []string{viper.GetString("ansible-playbook"), "-i", inv, "--list-hosts"},
+				Cwd:    a.Cwd,
+			}
 
-		vCmd := VenvCommand{
-			Config: a.VenvConfig,
-			Binary: "ansible-playbook",
-			Args:   []string{viper.GetString("ansible-playbook"), "-i", inv, "--list-hosts"},
-			Cwd:    a.Cwd,
-		}
+			output, _, err := vCmd.Run()
+			if err != nil {
+				logrus.Debugln("Ansible inventory output:", output)
+				return "", "", errors.Wrap(err, "unable to list hosts for "+item)
+			}
 
-		output, _, err := vCmd.Run()
-		if err != nil {
-			logrus.Debugln("Ansible inventory output:", output)
-			return "", errors.Wrap(err, "unable to list hosts for "+item)
-		}
+			if strings.Contains(output, target) {
+				logrus.Debug("Found ", target, " in inventory ", inv)
+				return inv, target, nil
+			}
 
-		if strings.Contains(output, host) {
-			logrus.Debug("Found ", host, " in inventory ", inv)
-			return inv, nil
+			logrus.Debug("Did not find ", target, " in inventory ", inv)
 		}
-
-		logrus.Debug("Did not find ", host, " in inventory ", inv)
 	}
-
-	return "", errors.New("Unable to detect hostname in any inventory: " + host)
+	return "", "", errors.New("Unable to find one of the target in any inventory")
 }
 
 // AnsibleNodeStatus contains status information for a single node's Ansible run.
@@ -76,7 +116,7 @@ type AnsibleNodeStatus struct {
 
 // AnsibleRunOutput is a collection of all of the information given by an Ansible run.
 type AnsibleRunOutput struct {
-	Stats map[string]AnsibleNodeStatus `json:"stats"`
+	Stats  map[string]AnsibleNodeStatus `json:"stats"`
 	Stdout string
 	Stderr string
 }

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -11,10 +11,11 @@ var _ = Describe("Ansible", func() {
 	Describe("ansible inventory and execution", func() {
 		Context("when assembling a target list", func() {
 			It("should include an ip and the hostame at least", func() {
-				targets, err := CreateAnsibleTargetsList()
-				hostname, _ = os.Hostname()
-				Expect(err).To(BeNil())
-				Expect(targets).ToNot(BeNil())
+				targets, targetErr := CreateAnsibleTargetsList()
+				hostname, hostnameErr := os.Hostname()
+				Expect(targetErr).To(BeNil())
+				Expect(hostnameErr).To(BeNil())
+				Expect(len(targets)).Should(BeNumerically(">=", 2))
 				Expect(targets).Should(ContainElement(ContainSubstring(hostname)))
 				Expect(targets).Should(ContainElement(MatchRegexp(`\d+\.\d+\.\d+.\d+`)))
 			})

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Ansible", func() {
+	Describe("ansible inventory and execution", func() {
+		Context("when assembling a target list", func() {
+			It("should include an ip and the hostame at least", func() {
+				targets, err := CreateAnsibleTargetsList()
+				hostname, _ = os.Hostname()
+				Expect(err).To(BeNil())
+				Expect(targets).ToNot(BeNil())
+				Expect(targets).Should(ContainElement(ContainSubstring(hostname)))
+				Expect(targets).Should(ContainElement(MatchRegexp(`\d+\.\d+\.\d+.\d+`)))
+			})
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -210,8 +210,8 @@ func ansibleRun() error {
 		InventoryList: viper.GetStringSlice("ansible-inventory"),
 	}
 
-	runLogger.Infoln("Finding inventory for host:", hostname)
-	inventory, err := aCfg.FindInventoryForHost(hostname)
+	runLogger.Infoln("Finding inventory for the current host")
+	inventory, target, err := aCfg.FindInventoryForHost()
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func ansibleRun() error {
 		AnsibleConfig:   aCfg,
 		PlaybookPath:    viper.GetString("ansible-playbook"),
 		InventoryPath:   inventory,
-		LimitExpr:       hostname,
+		LimitExpr:       target,
 		LocalConnection: true,
 	}
 

--- a/venv.go
+++ b/venv.go
@@ -90,7 +90,7 @@ func (c VenvCommand) Run() (string, string, error) {
 
 	path, ok := os.LookupEnv("PATH")
 	if !ok {
-		logrus.Error("unable to lookup the $PATH env variable")
+		return "", "", errors.New("Unable to lookup the $PATH env variable")
 	}
 
 	// Updating $PATH variable to include the venv path

--- a/venv.go
+++ b/venv.go
@@ -5,9 +5,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -85,6 +87,19 @@ func (c VenvCommand) Run() (string, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), venvCommandTimeout)
 
 	defer cancel() // The cancel should be deferred so resources are cleaned up
+
+	path, ok := os.LookupEnv("PATH")
+	if !ok {
+		logrus.Error("unable to lookup the $PATH env variable")
+	}
+
+	// Updating $PATH variable to include the venv path
+	venvPath := filepath.Join(c.Config.Path, "bin")
+	if !strings.Contains(path, venvPath) {
+		newVenvPath := fmt.Sprintf("%s:%s", filepath.Join(c.Config.Path, "bin"), path)
+		logrus.Debugln("PATH: ", newVenvPath)
+		os.Setenv("PATH", newVenvPath)
+	}
 
 	cmd := exec.CommandContext(
 		ctx,


### PR DESCRIPTION
```
go test 
{"level":"info","msg":"Disabled Ansible-Puller","time":"2019-09-09T15:45:47-07:00"}
Running Suite: Ansible Puller Suite
===================================
Random Seed: 1568069147
Will run 12 of 12 specs

••••••••••••
Ran 12 of 12 Specs in 0.017 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/teslamotors/ansible_puller	0.670s
```

With that code change, the execution will try to find the different ips of a host in the inventory and fallback to the hostname:

```
Sep 09 15:19:45 [...] time="2019-09-09T15:19:45-07:00" level=debug msg="Did not find 10.235.7.9 in inventory [...]"
[...]
Sep 09 15:19:50 [...] time="2019-09-09T15:19:50-07:00" level=debug msg="Did not find fe80::9:9cff:fec3:f43a in inventory [...]"
[...]
Sep 09 15:19:55 [...] time="2019-09-09T15:19:55-07:00" level=debug msg="Found ip-10-235-7-9.cn-north-1.compute.internal in inventory [...]"
```