### PR TITLE
Enable Better Run Introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Config file should be in: `/etc/ansible-puller/config.json`, `$HOME/.ansible-pul
 | `sleep`                  | `30`                                  | How often to trigger run events in minutes                                              |          |
 | `start-disabled`         | `false`                               | Whether or not to start wth Ansbile disabled (good for debugging)                       |          |
 | `debug`                  | `false`                               | Whether or not to start in debug mode                                                   |          |
+| `once`                   | `false`                               | Only run the configured playbook once and then stop                                     |          |
 
 ### Monitoring with prometheus
 
@@ -111,8 +112,17 @@ Note that this project uses packer v2.
 
 ### Doing Things
 
-To run locally: `go run .`
+#### Running Locally
+ 
+`go run .`
 
-To build a production release: `GOOS=linux GOARCH=amd64 packr2 build` (see [build-release.sh](build-release.sh))
+#### Building a Production Release
 
-For debugging the application, use the `--debug` flag, or the `debug` option in the config file. It'll make the logs a little easier to read.
+`GOOS=linux GOARCH=amd64 packr2 build` (see [build-release.sh](build-release.sh))
+
+#### Debugging an Ansible Run
+
+For debugging the application, use the `--debug` flag, or the `debug` option in the config file.
+This streams the Ansible output to the console so that you can follow along in the run.
+
+Also consider using the `--once` flag to run the process just once and then exit without spinning up the webserver.

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func init() {
 	pflag.Int("sleep", 30, "Number of minutes to sleep between runs")
 	pflag.Bool("start-disabled", false, "Whether or not to start the server disabled")
 	pflag.Bool("debug", false, "Start the server in debug mode")
+	pflag.Bool("once", false, "Run Ansible Puller just once, then exit")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -254,6 +255,14 @@ func ansibleRun() error {
 }
 
 func main() {
+	if viper.GetBool("once") {
+		if err := ansibleRun(); err != nil {
+			logrus.Fatalln("Ansible run failed due to: " + err.Error())
+		}
+
+		return
+	}
+
 	promVersion.WithLabelValues(Version).Set(1)
 
 	period := time.Duration(viper.GetInt("sleep")) * time.Minute

--- a/util.go
+++ b/util.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"os/exec"
+)
+
+// failedCommandLogger will print a bunch of context to the terminal when in debug mode
+func failedCommandLogger(cmd *exec.Cmd) {
+	if viper.GetBool("debug") {
+		logrus.Debug("failed command: ", cmd.Args)
+		logrus.Debug("stdout: ", cmd.Stdout)
+		logrus.Debug("stderr: ", cmd.Stderr)
+	}
+}


### PR DESCRIPTION
Debugging through the puller can be a pain. The JSON output is hard to visibly parse and figure out what went wrong.

These changes allow streaming the the Ansible Stdout/Stderr during the run when Debug mode is enabled.
This also introduces a `--once` flag that will not start the webserver so that you can do a quick debug run without needing to mess with the systemd-controlled process.