### PR TITLE
Fixed error with go-getter

### DIFF
--- a/go_getter_downloader.go
+++ b/go_getter_downloader.go
@@ -31,9 +31,9 @@ func (downloader goGetterDownloader) RemoteChecksum(remotePath string) (string, 
 	defer os.RemoveAll(dir)
 	hashFile := filepath.Join(dir, "md5Hash")
 
-	err = getter.GetFile(hashRemotePath, hashFile)
+	err = getter.GetFile(hashFile, hashRemotePath)
 	if err != nil {
-		logrus.Debugf("MD5 sum not reachable at: %s", hashRemotePath)
+		logrus.Infof("MD5 sum not reachable. %v", err)
 		return "", nil
 	}
 


### PR DESCRIPTION
If a MD5 hash isn't supplied the program fails-open and redownloads the file. The order of parameters was mixed-up here and our logging wasn't sufficient