### PR TITLE
Fix MD5 checksumming bug in ansible_puller

### DIFF
--- a/idempotent_download.go
+++ b/idempotent_download.go
@@ -53,7 +53,7 @@ func validateMd5Sum(path, checksum string) error {
 // The MD5 checking may be an Artifactory-specific setup because it will look for the hash at "${url}.md5"
 // If the MD5 is not found, this will download the file
 func idempotentFileDownload(downloader downloader, remotePath, localPath string) error {
-	logrus.Debugf("Starting idempotent download of %s", remotePath)
+	logrus.Debugf("Starting idempotent download of %s to %s", remotePath, localPath)
 
 	currentChecksum, err := md5sum(localPath)
 	if os.IsNotExist(err) {

--- a/s3_downloader.go
+++ b/s3_downloader.go
@@ -116,7 +116,7 @@ func (downloader s3Downloader) RemoteChecksum(remotePath string) (string, error)
 	defer os.RemoveAll(dir)
 	hashFile := filepath.Join(dir, "md5Hash")
 
-	err = downloader.Download(hashFile, hashRemotePath)
+	err = downloader.Download(hashRemotePath, hashFile)
 	if err != nil {
 		logrus.Infof("MD5 sum not reachable. %v", err)
 		return "", nil

--- a/unarchive.go
+++ b/unarchive.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"os"
@@ -31,6 +32,7 @@ func ensureGzip(file io.Reader) error {
 
 // Extract a tarball from the src into dest
 func extractTgz(src, dest string) error {
+	logrus.Debugf("Expanding %s to %s", src, dest)
 	tgzFile, err := os.Open(src)
 	if err != nil {
 		return errors.Wrap(err, "unable to open source file")


### PR DESCRIPTION
ansible_puller still works: This just prevents spurious downloads every 30 minutes

I've also added some logging statements (at "debug" level) which would probably be helpful