### PR TITLE
Fix mis-reported prometheus metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,11 +254,11 @@ func ansibleRun() error {
 		promAnsibleLastSuccess.Set(float64(time.Now().Unix()))
 	}
 
-	promAnsibleSummary.WithLabelValues("ok").Set(float64(runOutput.Stats[hostname].Ok))
-	promAnsibleSummary.WithLabelValues("skipped").Set(float64(runOutput.Stats[hostname].Skipped))
-	promAnsibleSummary.WithLabelValues("changed").Set(float64(runOutput.Stats[hostname].Changed))
-	promAnsibleSummary.WithLabelValues("failures").Set(float64(runOutput.Stats[hostname].Failures))
-	promAnsibleSummary.WithLabelValues("unreachable").Set(float64(runOutput.Stats[hostname].Unreachable))
+	promAnsibleSummary.WithLabelValues("ok").Set(float64(runOutput.Stats[target].Ok))
+	promAnsibleSummary.WithLabelValues("skipped").Set(float64(runOutput.Stats[target].Skipped))
+	promAnsibleSummary.WithLabelValues("changed").Set(float64(runOutput.Stats[target].Changed))
+	promAnsibleSummary.WithLabelValues("failures").Set(float64(runOutput.Stats[target].Failures))
+	promAnsibleSummary.WithLabelValues("unreachable").Set(float64(runOutput.Stats[target].Unreachable))
 
 	runLogger.Infoln("Writing ansible output to logfile")
 


### PR DESCRIPTION
The issue manifests as the prometheus counter ansible_puller_play_summary containing all zeros even with successful runs. This is due to two problems:
1) It is assumed in the counter logic that the hostname was the host alias used during the ansible playbook. This is not always correct.
2) During failures (and when "debug" is on), the ansible runner is exiting before parsing the metric result

This was manually tested in a "scratch" environment