### PR TITLE
Ad-hoc style fixes on error annotations and error formatting

### DIFF
--- a/ansible.go
+++ b/ansible.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func CreateAnsibleTargetsList() ([]string, error) {
 	for _, i := range ifaces {
 		addrs, err := i.Addrs()
 		if err != nil {
-			return []string{}, errors.Wrap(err, fmt.Sprintf("Unable to extract the ip addresses from %s", i.Name))
+			return []string{}, errors.Wrapf(err, "Unable to extract the ip addresses from %s", i.Name)
 		}
 		for _, addr := range addrs {
 			var ip net.IP

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -41,7 +41,7 @@ func (downloader httpDownloader) Download(remotePath, outputPath string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return errors.New(fmt.Sprintf("bad status code: %v", resp.StatusCode))
+		return fmt.Errorf("bad status code: %v", resp.StatusCode)
 	}
 
 	// Persist to file in 32K chunks, instead of slurping

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -78,7 +78,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 	remoteChecksum, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Debug("Error reading remote checksum")
-		return "", err
+		return "", errors.Wrap(err, "failed to read remote md5sum")
 	}
 
 	return string(remoteChecksum), nil


### PR DESCRIPTION
* Use errors.Wrapf which supports format strings.
* Use fmt.Errorf to create an error with format string.
* Wrap errors with annotations to help debugging: https://google.github.io/styleguide/go/best-practices.html#adding-information-to-errors