### PR TITLE
Handle the failure occurred when creating http request.

### DIFF
--- a/http_downloader.go
+++ b/http_downloader.go
@@ -31,7 +31,11 @@ func (downloader httpDownloader) Download(remotePath, outputPath string) error {
 		Timeout: 15 * time.Second,
 	}
 
-	req, _ := http.NewRequest("GET", remotePath, nil)
+	req, err := http.NewRequest("GET", remotePath, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create request")
+	}
+
 	if downloader.username != "" && downloader.password != "" {
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
@@ -63,7 +67,11 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 	client := http.Client{
 		Timeout: timeout,
 	}
-	req, _ := http.NewRequest("GET", hashRemotePath, nil)
+	req, err := http.NewRequest("GET", hashRemotePath, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create request")
+	}
+
 	if downloader.username != "" && downloader.password != "" {
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}

--- a/http_downloader_test.go
+++ b/http_downloader_test.go
@@ -219,3 +219,9 @@ func (s *HttpDownloaderTestSuite) TestIdempotentDownloadBasicAuthFailure() {
 	err := idempotentFileDownload(downloader, s.testServer.URL+"/"+testBasicAuthFilename, testBasicAuthFilename)
 	assert.NotNil(s.T(), err)
 }
+
+func (s *HttpDownloaderTestSuite) TestIdempotentDownloadFailureFromInvalidURL() {
+	downloader := httpDownloader{}
+	err := idempotentFileDownload(downloader, "http://192.168.0.%31/invalid-url", testFilename)
+	assert.NotNil(s.T(), err)
+}


### PR DESCRIPTION
`http.NewRequest` can yield error, and we must handle it or we are risking panics in certain situations.

See: https://github.com/golang/go/wiki/CodeReviewComments#handle-errors
