### PR TITLE
Handle 404 not found of retrieving md5sum using status code.

### DIFF
--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,6 +76,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
+	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, _ := client.Do(req)
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,9 +76,11 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
+	resp, _ := client.Do(req)
+	// Ignore the checksum if it's not found, as assumed by the caller of this function.
+	if resp.StatusCode == http.StatusNotFound {
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
+		return "", nil
 	}
 
 	logrus.Debugf("Found MD5 sum at: %s", hashRemotePath)


### PR DESCRIPTION
`http.Client.Do` never returns error for non-2xx status code according to the doc. Therefore we must rely on the status code to check for 404 not found. We will fix the error handling in later PRs.

> An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem). A non-2xx status code doesn't cause an error.
> https://pkg.go.dev/net/http#Client.Do

This PR also makes the empty md5sum return explicitly and uses a quick-return pattern. https://github.com/golang/go/wiki/CodeReviewComments#indent-error-flow
