### PR TITLE
Handle other non-successful status code to avoid reading bad data as md5sum.

### DIFF
--- a/http_downloader.go
+++ b/http_downloader.go
@@ -83,6 +83,9 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
 		return "", nil
 	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("bad status code: %v", resp.StatusCode)
+	}
 
 	logrus.Debugf("Found MD5 sum at: %s", hashRemotePath)
 	defer resp.Body.Close()

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,7 +76,6 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
-	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, _ := client.Do(req)
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,6 +76,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
+	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, _ := client.Do(req)
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {

--- a/idempotent_download.go
+++ b/idempotent_download.go
@@ -3,10 +3,11 @@ package main
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"errors"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Interface with logic to govern how to actually pull objects
@@ -60,12 +61,12 @@ func idempotentFileDownload(downloader downloader, remotePath, localPath string)
 		logrus.Infof("File '%s' does not exist yet so cannot validate for new checksum", localPath)
 		currentChecksum = ""
 	} else if err != nil {
-		return err
+		return errors.Wrap(err, "failed to calc local md5sum")
 	}
 
 	remoteChecksum, err := downloader.RemoteChecksum(remotePath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to download md5sum")
 	}
 
 	if currentChecksum != "" && remoteChecksum != "" {
@@ -80,7 +81,7 @@ func idempotentFileDownload(downloader downloader, remotePath, localPath string)
 	logrus.Infof("Downloading file: %s", remotePath)
 	err = downloader.Download(remotePath, localPath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to download")
 	}
 
 	if remoteChecksum != "" {
@@ -88,7 +89,7 @@ func idempotentFileDownload(downloader downloader, remotePath, localPath string)
 
 		err = validateMd5Sum(localPath, remoteChecksum)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to validate md5sum")
 		}
 	}
 


### PR DESCRIPTION
Let's follow the error handling used in the downloader to handle other non-successful status code properly. This PR also adds error annotations to the idempotent downloader to add more debug context.
