### PR TITLE
Handle `http.Client.Do` error properly to avoid segfaults.

### DIFF
--- a/http_downloader.go
+++ b/http_downloader.go
@@ -83,6 +83,9 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
 		return "", nil
 	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("bad status code: %v", resp.StatusCode)
+	}
 
 	logrus.Debugf("Found MD5 sum at: %s", hashRemotePath)
 	defer resp.Body.Close()

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,15 +76,11 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
-	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, _ := client.Do(req)
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
 		return "", nil
-	}
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("bad status code: %v", resp.StatusCode)
 	}
 
 	logrus.Debugf("Found MD5 sum at: %s", hashRemotePath)

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,8 +76,11 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
+	resp, err := client.Do(req)
 	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
-	resp, _ := client.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get remote md5sum")
+	}
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,6 +76,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
+	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, _ := client.Do(req)
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,7 +76,6 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
-	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get remote md5sum")
@@ -86,6 +85,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
 		return "", nil
 	}
+	// A non-2xx status code does not cause an error, so we handle it here. https://pkg.go.dev/net/http#Client.Do
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("bad status code: %v", resp.StatusCode)
 	}

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -76,8 +76,8 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
 
-	resp, err := client.Do(req)
 	// A non-2xx status code does not cause an error. https://pkg.go.dev/net/http#Client.Do
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get remote md5sum")
 	}

--- a/http_downloader_test.go
+++ b/http_downloader_test.go
@@ -225,3 +225,9 @@ func (s *HttpDownloaderTestSuite) TestIdempotentDownloadFailureFromInvalidURL() 
 	err := idempotentFileDownload(downloader, "http://192.168.0.%31/invalid-url", testFilename)
 	assert.NotNil(s.T(), err)
 }
+
+func (s *HttpDownloaderTestSuite) TestIdempotentDownloadFailureFromUnresponsiveServer() {
+	downloader := httpDownloader{}
+	err := idempotentFileDownload(downloader, "http://0.0.0.0/unresponsive/"+testFilename, testFilename)
+	assert.NotNil(s.T(), err)
+}


### PR DESCRIPTION
If the endpoint is unresponsive due to an outage, `http.Client.Do` can yield error. We must handle this error, or we would access an undefined response and traps segfault and crashes the daemon.

This PR also adds a test to catch this situation.

> An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem). A non-2xx status code doesn't cause an error.
> https://pkg.go.dev/net/http#Client.Do
