### PR TITLE
Add git hash as version information via Bazel stamp.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,7 @@
+# Bazel stamp variable generations
+build --workspace_status_command=$(pwd)/ws_status.sh
+
+# For release
+# To use it: bazel COMMAND --config=release
+build:release --compilation_mode=opt
+build:release --stamp

--- a/BUILD
+++ b/BUILD
@@ -58,6 +58,7 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",
     ],
+    x_defs = {"main.Version": "{STABLE_GIT_COMMIT}"}
 )
 
 #

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ or, without bazel
 
 #### Building a Production Release
 
-`bazelisk build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //...`
+`bazelisk build --config=release --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //...`
 
 #### Building Production Packages
 
-* `bazelisk build //:ansible_puller_deb`
-* `bazelisk build //:ansible_puller_rpm`
+* `bazelisk build --config=release //:ansible_puller_deb`
+* `bazelisk build --config=release //:ansible_puller_rpm`
 
 
 #### Debugging an Ansible Run

--- a/ws_status.sh
+++ b/ws_status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Generates the data used by the stamping feature in bazel.
+
+echo STABLE_GIT_COMMIT "$(git rev-parse HEAD)"


### PR DESCRIPTION
ansible-puller used to include its git sha as version https://github.com/teslamotors/ansible_puller/blob/e93c507dae6f92fc4ed2ec205a86cf6603ed7467/build-release.sh. This logic was missed out during the migration to Bazel. This PR adds it back to be consistent so that the Prometheus metric can show the current git build hash.