### PR TITLE
Add support for custom md5 remote path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Config file should be in: `/etc/ansible-puller/config.json`, `$HOME/.ansible-pul
 | `http-user`              | `""`                                  | Username for HTTP Basic Auth                                                            |
 | `http-pass`              | `""`                                  | Password for HTTP basic Auth                                                            |
 | `http-url`               | `""`                                  | HTTP Url to find the Ansible tarball. Required if s3-arn is not set                     |
-| `http-checksum-url`      | `""`                                  | HTTP Url to find the Ansible tarball checksum. Defaults to http-url + `.md5`.           |
+| `http-checksum-url`      | `""`                                  | HTTP Url to find the Ansible tarball md5 hash. Defaults to http-url + `.md5`.           |
 | `log-dir`                | `"/var/log/ansible-puller"`           | Log directory (must exist)                                                              |
 | `ansible-dir`            | `""`                                  | Path in the pulled tarball to cd into before ansible commands - usually ansible.cfg dir |
 | `ansible-playbook`       | `"site.yml"`                          | The playbook that will be run  - relative to ansible-dir                                |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Config file should be in: `/etc/ansible-puller/config.json`, `$HOME/.ansible-pul
 | `http-user`              | `""`                                  | Username for HTTP Basic Auth                                                            |
 | `http-pass`              | `""`                                  | Password for HTTP basic Auth                                                            |
 | `http-url`               | `""`                                  | HTTP Url to find the Ansible tarball. Required if s3-arn is not set                     |
+| `http-checksum-url`      | `""`                                  | HTTP Url to find the Ansible tarball checksum. Defaults to http-url + `.md5`.           |
 | `log-dir`                | `"/var/log/ansible-puller"`           | Log directory (must exist)                                                              |
 | `ansible-dir`            | `""`                                  | Path in the pulled tarball to cd into before ansible commands - usually ansible.cfg dir |
 | `ansible-playbook`       | `"site.yml"`                          | The playbook that will be run  - relative to ansible-dir                                |
@@ -104,8 +105,9 @@ remote.
 
 By design, ansible_puller will look at the remote path `<resource_path>.md5` to discover the live
 MD5 checksum. If, for example, your resource is located at `https://example.com/some/file.tgz` then
-ansible_puller will look for the MD5 hash at `https://example.com/some/file.tgz.md5`. The following
-conditions will lead to a (re-)download of the ansible tarball:
+ansible_puller will look for the MD5 hash at `https://example.com/some/file.tgz.md5`. A custom remote
+path can be specified with the `http-checksum-url` option.
+The following conditions will lead to a (re-)download of the ansible tarball:
 - There is no current ansible tarball at the specified local path
 - The current hash of the local ansible tarball not match the remote checksum
 - The remote checksum does not exist

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -60,14 +60,13 @@ func (downloader httpDownloader) Download(remotePath, outputPath string) error {
 	return nil
 }
 
-func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, error) {
-	hashRemotePath := fmt.Sprintf("%s.md5", remotePath)
+func (downloader httpDownloader) RemoteChecksum(checksumURL string) (string, error) {
 
 	timeout := time.Duration(2 * time.Second)
 	client := http.Client{
 		Timeout: timeout,
 	}
-	req, err := http.NewRequest("GET", hashRemotePath, nil)
+	req, err := http.NewRequest("GET", checksumURL, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create request")
 	}
@@ -82,7 +81,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 	}
 	// Ignore the checksum if it's not found, as assumed by the caller of this function.
 	if resp.StatusCode == http.StatusNotFound {
-		logrus.Debugf("MD5 sum not found at: %s", hashRemotePath)
+		logrus.Debugf("MD5 sum not found at: %s", checksumURL)
 		return "", nil
 	}
 	// A non-2xx status code does not cause an error, so we handle it here. https://pkg.go.dev/net/http#Client.Do
@@ -90,7 +89,7 @@ func (downloader httpDownloader) RemoteChecksum(remotePath string) (string, erro
 		return "", fmt.Errorf("bad status code: %v", resp.StatusCode)
 	}
 
-	logrus.Debugf("Found MD5 sum at: %s", hashRemotePath)
+	logrus.Debugf("Found MD5 sum at: %s", checksumURL)
 	defer resp.Body.Close()
 	remoteChecksum, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func init() {
 	pflag.String("http-pass", "", "HTTP password for pulling the remote file")
 
 	pflag.String("http-url", "", "Remote endpoint to retrieve the file from")
+	pflag.String("http-checksum-url", "", "Remote endpoint to retrieve the checksum from")
 	pflag.String("s3-arn", "", "Remote object ARN in S3 to retrieve")
 	pflag.String("s3-conn-region", "", "AWS service endpoint region for S3")
 
@@ -153,6 +154,7 @@ func ansibleEnable() {
 
 func getAnsibleRepository(runDir string) error {
 	httpURL := viper.GetString("http-url")
+	checksumURL := viper.GetString("http-checksum-url")
 	s3Obj := viper.GetString("s3-arn")
 	s3ConnectionRegion := viper.GetString("s3-conn-region")
 	localCacheFile := fmt.Sprintf("/tmp/%s.tgz", appName)
@@ -167,13 +169,13 @@ func getAnsibleRepository(runDir string) error {
 			username: viper.GetString("http-user"),
 			password: viper.GetString("http-pass"),
 		}
-		err = idempotentFileDownload(downloader, remoteHttpURL, localCacheFile)
+		err = idempotentFileDownload(downloader, remoteHttpURL, checksumURL, localCacheFile)
 	} else if s3Obj != "" {
 		downloader, createError := createS3Downloader(s3ConnectionRegion)
 		if createError != nil {
 			return errors.Wrap(err, "unable to pull Ansible repo")
 		}
-		err = idempotentFileDownload(downloader, s3Obj, localCacheFile)
+		err = idempotentFileDownload(downloader, s3Obj, checksumURL, localCacheFile)
 	}
 	if err != nil {
 		return errors.Wrap(err, "unable to pull Ansible repo")

--- a/s3_downloader.go
+++ b/s3_downloader.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"regexp"
 
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
-	"path/filepath"
 )
 
 type s3Downloader struct {
@@ -105,8 +106,7 @@ func (downloader s3Downloader) Download(remotePath, outputPath string) (err erro
 	return
 }
 
-func (downloader s3Downloader) RemoteChecksum(remotePath string) (string, error) {
-	hashRemotePath := fmt.Sprintf("%s.md5", remotePath)
+func (downloader s3Downloader) RemoteChecksum(checksumURL string) (string, error) {
 
 	dir, err := ioutil.TempDir("", "*")
 	if err != nil {
@@ -116,13 +116,13 @@ func (downloader s3Downloader) RemoteChecksum(remotePath string) (string, error)
 	defer os.RemoveAll(dir)
 	hashFile := filepath.Join(dir, "md5Hash")
 
-	err = downloader.Download(hashRemotePath, hashFile)
+	err = downloader.Download(checksumURL, hashFile)
 	if err != nil {
 		logrus.Infof("MD5 sum not reachable. %v", err)
 		return "", nil
 	}
 
-	logrus.Infof("Found MD5 sum at: %s", hashRemotePath)
+	logrus.Infof("Found MD5 sum at: %s", checksumURL)
 
 	content, err := ioutil.ReadFile(hashFile)
 	if err != nil {


### PR DESCRIPTION
We use the gitlab package registry to store ansible playbook releases. Gitlab has permalinks to the latest artifacts or to release assets. These links to artifacts or release assets are accessed using the gitlab API and my not be the actual path to the tarball or md5 checksum file. 

A custom remote path for the link to the md5 hash would be very nice! This PR will add  a `http-checksum-url` flag. If the `http-checksum-url` flag has not been set, it will use the `http-url` with `.md5` added to the path.