### PR TITLE
migrated functionality to use venv instead of virtualenv

### DIFF
--- a/venv.go
+++ b/venv.go
@@ -30,14 +30,9 @@ type VenvConfig struct {
 
 // Takes a VenvConfig and will create a new virtual environment.
 func makeVenv(cfg VenvConfig) error {
-	venvExecutable, err := exec.LookPath("virtualenv")
-	if err != nil {
-		return errors.Wrap(err, "virtualenv not found in path")
-	}
+	cmd := exec.Command(cfg.Python, "-m", "venv", cfg.Path)
 
-	cmd := exec.Command(venvExecutable, "--python", cfg.Python, cfg.Path)
-
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		failedCommandLogger(cmd)
 		return errors.Wrap(err, "unable to create virtual environment")

--- a/venv.go
+++ b/venv.go
@@ -37,6 +37,7 @@ func makeVenv(cfg VenvConfig) error {
 	}
 	logrus.Debugln("Detected Python version:", pythonVersion)
 
+        // venv was introduced in python version 3.3
 	useVenv := pythonVersionAtLeast(pythonVersion, 3, 3)
 	logrus.Debugln("Use venv:", useVenv)
 

--- a/venv.go
+++ b/venv.go
@@ -40,7 +40,16 @@ func makeVenv(cfg VenvConfig) error {
 	useVenv := pythonVersionAtLeast(pythonVersion, 3, 3)
 	logrus.Debugln("Use venv:", useVenv)
 
-	cmd := exec.Command(cfg.Python, "-m", "venv", cfg.Path)
+	var cmd *exec.Cmd
+	if useVenv {
+		cmd = exec.Command(cfg.Python, "-m", "venv", cfg.Path)
+	} else {
+		venvExecutable, err := exec.LookPath("virtualenv")
+		if err != nil {
+			return errors.Wrap(err, "virtualenv not found in path")
+		}
+		cmd = exec.Command(venvExecutable, "--python", cfg.Python, cfg.Path)
+	}
 
 	err = cmd.Run()
 	if err != nil {

--- a/venv.go
+++ b/venv.go
@@ -33,7 +33,7 @@ type VenvConfig struct {
 func makeVenv(cfg VenvConfig) error {
 	pythonVersion, err := getPythonVersion(cfg.Python)
 	if err != nil {
-	        return errors.Wrap(err, "unable to determine Python version")
+		return errors.Wrap(err, "unable to determine Python version")
 	}
 	logrus.Debugln("Detected Python version:", pythonVersion)
 
@@ -53,8 +53,8 @@ func makeVenv(cfg VenvConfig) error {
 
 	err = cmd.Run()
 	if err != nil {
-	        failedCommandLogger(cmd)
-	        return errors.Wrap(err, "unable to create virtual environment")
+		failedCommandLogger(cmd)
+		return errors.Wrap(err, "unable to create virtual environment")
 	}
 
 	return nil
@@ -97,13 +97,13 @@ func getPythonVersion(python string) (string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-	        return "", errors.Wrap(err, "unable to execute Python version command")
+		return "", errors.Wrap(err, "unable to execute Python version command")
 	}
 
 	versionOutput := strings.TrimSpace(out.String())
 	parts := strings.Fields(versionOutput)
 	if len(parts) != 2 {
-	        return "", errors.New("unexpected output from Python version command")
+		return "", errors.New("unexpected output from Python version command")
 	}
 
 	return parts[1], nil

--- a/venv.go
+++ b/venv.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,9 @@ func makeVenv(cfg VenvConfig) error {
 	}
 	logrus.Debugln("Detected Python version:", pythonVersion)
 
+	useVenv := pythonVersionAtLeast(pythonVersion, 3, 3)
+	logrus.Debugln("Use venv:", useVenv)
+
 	cmd := exec.Command(cfg.Python, "-m", "venv", cfg.Path)
 
 	err = cmd.Run()
@@ -45,6 +49,34 @@ func makeVenv(cfg VenvConfig) error {
 	}
 
 	return nil
+}
+
+// pythonVersionAtLeast checks if the Python version is at least major.minor.
+func pythonVersionAtLeast(version string, major int, minor int) bool {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	majorVersion, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+
+	minorVersion, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+
+	if majorVersion > major {
+		return true
+	}
+
+	if majorVersion == major && minorVersion >= minor {
+		return true
+	}
+
+	return false
 }
 
 // getPythonVersion returns the Python version as a string.


### PR DESCRIPTION
Potential fix for the virtualenv describe here: https://github.com/teslamotors/ansible_puller/issues/50

The PR uses venv instead of virtualenv to create the virtual environment.