### PR TITLE
Add auth header support.

### DIFF
--- a/http_downloader.go
+++ b/http_downloader.go
@@ -16,8 +16,10 @@ import (
 
 type httpDownloader struct {
 	downloader
-	username string
-	password string
+	username    string
+	password    string
+	headerName  string
+	headerValue string
 }
 
 func (downloader httpDownloader) Download(remotePath, outputPath string) error {
@@ -38,6 +40,9 @@ func (downloader httpDownloader) Download(remotePath, outputPath string) error {
 
 	if downloader.username != "" && downloader.password != "" {
 		req.SetBasicAuth(downloader.username, downloader.password)
+	}
+	if downloader.headerName != "" && downloader.headerValue != "" {
+		req.Header.Set(downloader.headerName, downloader.headerValue)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -74,7 +79,9 @@ func (downloader httpDownloader) RemoteChecksum(checksumURL string) (string, err
 	if downloader.username != "" && downloader.password != "" {
 		req.SetBasicAuth(downloader.username, downloader.password)
 	}
-
+	if downloader.headerName != "" && downloader.headerValue != "" {
+		req.Header.Set(downloader.headerName, downloader.headerValue)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get remote md5sum")

--- a/http_downloader_test.go
+++ b/http_downloader_test.go
@@ -18,8 +18,8 @@ var (
 	testFilenameHash = "testfile.txt.md5"
 	testMD5          = "7b20fda6af27c1b59ebdd8c09a93e770"
 
-  testEmptyChecksumUrl  = ""
-  testChecksumUrlPath   = "custom.txt.md5"
+	testEmptyChecksumUrl = ""
+	testChecksumUrlPath  = "custom.txt.md5"
 
 	testHashlessFilename = "nohash.txt"
 	testHashlessText     = []byte("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.")
@@ -68,7 +68,7 @@ func (s *HttpDownloaderTestSuite) SetupTest() {
 					rw.Write(testText)
 				case "/" + testFilenameHash:
 					rw.Write([]byte(testMD5))
-        case "/" + testChecksumUrlPath:
+				case "/" + testChecksumUrlPath:
 					rw.Write([]byte(testMD5))
 				case "/" + testHashlessFilename:
 					rw.Write(testHashlessText)

--- a/main.go
+++ b/main.go
@@ -87,7 +87,8 @@ func init() {
 	pflag.String("http-proto", "https", "Set to 'http' if necessary")
 	pflag.String("http-user", "", "HTTP username for pulling the remote file")
 	pflag.String("http-pass", "", "HTTP password for pulling the remote file")
-
+	pflag.String("http-header-name", "", "HTTP header name")
+	pflag.String("http-header-value", "", "HTTP header value")
 	pflag.String("http-url", "", "Remote endpoint to retrieve the file from")
 	pflag.String("http-checksum-url", "", "Remote endpoint to retrieve the checksum from")
 	pflag.String("s3-arn", "", "Remote object ARN in S3 to retrieve")
@@ -168,6 +169,8 @@ func getAnsibleRepository(runDir string) error {
 		downloader := httpDownloader{
 			username: viper.GetString("http-user"),
 			password: viper.GetString("http-pass"),
+			headerName: viper.GetString("http-header-name"),
+			headerValue: viper.GetString("http-header-value"),
 		}
 		err = idempotentFileDownload(downloader, remoteHttpURL, checksumURL, localCacheFile)
 	} else if s3Obj != "" {


### PR DESCRIPTION
This makes it possible to authenticate with the gitlab or github API by specifying a `PRIVATE-TOKEN` or `Authorization` header with the http request.

Now you can download the ansible source tarball and md5 directly from the gitlab or github package registry using the gitlab API.

example config:

```
{
  "http-url": "gitlab.ops.catdevbrain.lan/api/v4/projects/4/jobs/artifacts/main/raw/catdevbrain-ansible-latest.tar.gz?job=build_latest",
  "http-checksum-url": "gitlab.ops.catdevbrain.lan/api/v4/projects/4/jobs/artifacts/main/raw/catdevbrain-ansible-latest.tar.gz.md5?job=build_latest",
  "http-proto": "https",
  "http-header-name": "PRIVATE-TOKEN",
  "http-header-value": "<REDACTED>",
  "ansible-dir": "ansible",
  "ansible-inventory": ["inventories/catdevbrain"],
  "playbook": "site.yml",
  "sleep": "10",
  "sleep-jitter": "5"
}
```