### PR TITLE
Fixed the run output log files to be populated when debug=true 

### DIFF
--- a/venv.go
+++ b/venv.go
@@ -157,14 +157,14 @@ type VenvCommandRunOutput struct {
 
 func streamOutput(stream io.ReadCloser, outString *string) error {
 	var buff bytes.Buffer
-	scanner := bufio.NewScanner(stream)
+	reader := io.TeeReader(stream, &buff)
+
+	scanner := bufio.NewScanner(reader)
 	scanner.Split(bufio.ScanLines)
 
 	for scanner.Scan() {
 		m := scanner.Text()
 		fmt.Println(m)
-		buff.WriteString(m)
-		buff.WriteString("\n")
 	}
 	*outString = fmt.Sprint(buff.String())
 

--- a/venv.go
+++ b/venv.go
@@ -210,18 +210,19 @@ func (c VenvCommand) Run() VenvCommandRunOutput {
 
 		for stream, out := range output {
 			go func(s io.ReadCloser, o *string) {
-				var bufstdout bytes.Buffer
+				var buff bytes.Buffer
 				
 				scanner := bufio.NewScanner(s)
 				scanner.Split(bufio.ScanLines)
-					
+
 				for scanner.Scan() {
 					m := scanner.Text()
 					fmt.Println(m)
-					bufstdout.WriteString(m)
-					bufstdout.WriteString("\n")
+					buff.WriteString(m)
+					buff.WriteString("\n")
 				}
-				*o = fmt.Sprint(bufstdout.String())
+				*o = fmt.Sprint(buff.String())
+				
 			}(stream, out)
 		}
 

--- a/venv.go
+++ b/venv.go
@@ -157,16 +157,15 @@ type VenvCommandRunOutput struct {
 
 func streamOutput(stream io.ReadCloser, outString *string) error {
 	var buff bytes.Buffer
-	reader := io.TeeReader(stream, &buff)
 
-	scanner := bufio.NewScanner(reader)
+	scanner := bufio.NewScanner(io.TeeReader(stream, &buff))
 	scanner.Split(bufio.ScanLines)
 
 	for scanner.Scan() {
 		m := scanner.Text()
 		fmt.Println(m)
 	}
-	*outString = fmt.Sprint(buff.String())
+	*outString = buff.String()
 
 	return nil
 }


### PR DESCRIPTION
Issue with the logs being output to file when debug flag is set to true.
When the debug=true the StreamOuput code block only streams the output to STDOUT and fails to populate the stdout and stderr field.
